### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "coverageReporters": ["lcov", "json", "html", "text-summary"],
     "collectCoverageFrom": [
       "**/*.js",
+      "!.eslintrc.js",
       "!**/node_modules/**",
       "!**/test/**",
       "!**/coverage/**",


### PR DESCRIPTION
Hey there, Dave here with Code Climate. After looking our backend, I see that we were getting test results from this repo, but your .`eslintrc.js` was being included in the reports, which invalidated the coverage payload. This PR removes that `.eslintrc.js` and will allow your coverage payload to process as expected. I've tested this out in my fork [here](https://github.com/davehenton/rytmi-api/blob/master/package.json)