### PR TITLE
Fix api tests

### DIFF
--- a/src/controllers/employeeRoles/index.js
+++ b/src/controllers/employeeRoles/index.js
@@ -12,7 +12,6 @@ employeeRoleController.update = wrapAsync(async (req, res) => {
 })
 
 employeeRoleController.delete = wrapAsync(async (req, res) => {
-  console.log(req)
   const action = await employeeRoleService.delete(req.params.id)
   res.json(action)
 })

--- a/src/services/crud.js
+++ b/src/services/crud.js
@@ -5,7 +5,7 @@ export default class CrudService {
 
   get (id) {
     return this.model
-      .findById(id, {attributes: { exclude: ['deletedAt'] }})
+      .findByPk(id, {attributes: { exclude: ['deletedAt'] }})
   }
 
   getAll () {

--- a/src/services/skills/index.js
+++ b/src/services/skills/index.js
@@ -7,7 +7,7 @@ export default class SkillService extends CrudService {
   }
 
   removedDeletedAt (id) {
-    return this.model.findById(id, { paranoid: false }).then(model => {
+    return this.model.findByPk(id, { paranoid: false }).then(model => {
       model.setDataValue('deletedAt', null)
       return model.save({ paranoid: false })
     })

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -32,7 +32,8 @@ export const genericDelete = async (model, modelDescription, id, foreignKeyId) =
 
 export const genericUpdate = async (model, modelDescription, id, attributes, foreignKeyId, getFunction, descriptionsPropertyName = 'descriptions') => {
   await model.update(attributes, { where: { id } })
-  for (const description of attributes[descriptionsPropertyName]) {
+  const descriptions = attributes[descriptionsPropertyName] ? attributes[descriptionsPropertyName] : []
+  for (const description of descriptions) {
     if (description.id) {
       await modelDescription.update(description, {where: {id: description.id}})
     } else {
@@ -49,7 +50,8 @@ export const genericCreate = async (model, modelDescription, attributes, foreign
     .build(attributes)
     .save()
     .then(createdModel => getFunction(createdModel.id))
-  for (const description of attributes[descriptionsPropertyName]) {
+  const descriptions = attributes[descriptionsPropertyName] ? attributes[descriptionsPropertyName] : []
+  for (const description of descriptions) {
     let newDesciption = { ...description }
     newDesciption[foreignKeyId] = newModel.id
     await modelDescription.build(newDesciption).save()

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -12,7 +12,7 @@ export const genericGetAll = async (model, modelDescription, mapDescriptionsToMo
 }
 
 export const genericGet = async (model, modelDescription, mapDescriptionsToModelFunction, id, foreignKeyId) => {
-  const modelInstance = await model.findById(id, {attributes: { exclude: ['deletedAt'] }})
+  const modelInstance = await model.findByPk(id, {attributes: { exclude: ['deletedAt'] }})
   let whereParameters = {}
   whereParameters[foreignKeyId] = id
   const modelInstanceDescriptions = await modelDescription.findAll({ where: whereParameters })

--- a/test/api/profiles.spec.js
+++ b/test/api/profiles.spec.js
@@ -8,7 +8,7 @@ import {
   user as userModel,
   skill as skillModel,
   profileSkill as profileSkillModel,
-  profileProject as ppModel
+  profileProject as profileProjectModel
 } from '../../src/db/models'
 import { profiles } from '../mockData/mockUsers'
 
@@ -32,18 +32,20 @@ describe('API profile endpoint', () => {
       exp: Date.now() + 3600
     })
     const firstProfileProject = {
+      id: 3589,
       profileId: normalUser.id,
       projectId: 1,
       workPercentage: 100,
       startDate: new Date('2019-10-01').toISOString(),
       endDate: new Date('2019-10-31').toISOString()
     }
-    profileProject = await ppModel.create(firstProfileProject)
+    profileProject = await profileProjectModel.create(firstProfileProject)
     request.set('Authorization', `Bearer ${jwtToken}`)
   })
 
   afterAll(async () => {
     await profileSkillModel.destroy({ where: {}, truncate: true, force: true })
+    await profileProjectModel.destroy({ where: {id: 3589} })
   })
 
   describe('Fetching profiles', () => {
@@ -101,7 +103,7 @@ describe('API profile endpoint', () => {
         email: 'some.user@codento.com',
         phone: '0401231234',
         title: 'Consultant',
-        description: 'Just consulting about everything',
+        cvDescriptions: [],
         links: [],
         photoPath: 'from/somewhere',
         active: true

--- a/test/api/projects.spec.js
+++ b/test/api/projects.spec.js
@@ -6,7 +6,8 @@ import { createUserToken, invalidToken, testAdminToken } from './tokens'
 import {
   user as userModel,
   project as projectModel,
-  profileProject as ppModel
+  profileProject as profileProjectModel,
+  profileProjectDescription as profileProjectDescriptionModel
 } from '../../src/db/models'
 import { projects } from '../mockData/mockProjects'
 
@@ -29,7 +30,9 @@ describe('API Projects endpoint', () => {
     request.set('Authorization', `Bearer ${jwtToken}`)
   })
   afterAll(async () => {
-    await ppModel.destroy({ where: {}, truncate: true, force: true })
+    // profileProjects are created in 'Creating project profiles'
+    const [reactProject, onGoingProject] = await projectModel.findAll()
+    profileProjectModel.destroy({ where: {projectId: [reactProject.id, onGoingProject.id]} })
   })
 
   describe('Fetching projects', () => {
@@ -44,7 +47,9 @@ describe('API Projects endpoint', () => {
 
     it('should allow authorized user to fetch specific project', async () => {
       const [reactProject] = projects
-      const expectedProject = await projectModel.findOne({ where: { name: reactProject.name } })
+      // id generation is handled with autoincrement field => first item in mock data will be id=1
+      reactProject.id = 1
+      const expectedProject = await projectModel.findOne({ where: { id: reactProject.id } })
       const response = await request.get(projectEndpoint + expectedProject.id).expect(200)
       expect(response.body).toMatchObject(reactProject)
     })
@@ -53,21 +58,36 @@ describe('API Projects endpoint', () => {
     it('should allow authorized user to create a project', async () => {
       const leanWorkshop = {
         code: 1010,
-        name: 'Lean workshop',
         startDate: new Date('2019-02-20').toISOString(),
-        endDate: new Date('2019-02-20').toISOString(),
-        description: 'Lean workshop for customer'
+        endDate: new Date('2019-02-21').toISOString(),
+        descriptions: [
+          {
+            description: 'Lean workshop for customer',
+            name: 'Lean workshop',
+            language: 'en',
+            customerName: 'Best customer ever'
+          }
+        ],
+        isSecret: false
       }
       const response = await request.post(projectEndpoint).send(leanWorkshop).expect(201)
       expect(response.body).toMatchObject(leanWorkshop)
+      refactoringProjectId = response.body.id
     })
 
     it('should allow authorized user to create a project without end date', async () => {
       const refactoringCode = {
         code: 1050,
-        name: 'Refactoring old code',
         startDate: new Date('2019-02-20').toISOString(),
-        description: 'This should be continuous'
+        descriptions: [
+          {
+            description: 'This should be continuous',
+            name: 'Refactoring old code',
+            language: 'en',
+            customerName: 'The favourite'
+          }
+        ],
+        isSecret: false
       }
       const response = await request.post(projectEndpoint).send(refactoringCode).expect(201)
       expect(response.body).toMatchObject(refactoringCode)
@@ -86,9 +106,8 @@ describe('API Projects endpoint', () => {
   describe('Updating projects', () => {
     it('should allow authorized user to edit project', async () => {
       const [reactProject] = projects
-      const expectedProject = await projectModel.findOne({ where: { name: reactProject.name } })
-      reactProject.name = 'Address app for lost'
-      expectedProject.name = 'Address app for lost'
+      const expectedProject = await projectModel.findOne({ where: { id: reactProject.id } })
+      reactProject.descriptions[0].name = 'Address app for lost'
       const response = await request.put(projectEndpoint + expectedProject.id).send(reactProject).expect(200)
       expect(response.body).toMatchObject(reactProject)
     })
@@ -99,6 +118,7 @@ describe('API Projects endpoint', () => {
     let reactProjectProfile, onGoingProjectProfile
 
     beforeAll(async () => {
+      // teared down in parent afterAll()
       const [reactProject, onGoingProject] = await projectModel.findAll()
       reactProjectId = reactProject.id
       onGoingProjectId = onGoingProject.id
@@ -164,23 +184,30 @@ describe('API Projects endpoint', () => {
     describe('projects', () => {
       const leanWorkshop = {
         code: 1010,
-        name: 'Lean workshop',
         startDate: new Date('2019-02-20').toISOString(),
-        endDate: new Date('2019-02-20').toISOString(),
-        description: 'Lean workshop for customer'
+        endDate: new Date('2019-02-21').toISOString(),
+        descriptions: [
+          {
+            description: 'Lean workshop for customer',
+            name: 'Lean workshop',
+            language: 'en',
+            customerName: 'Best customer ever'
+          }
+        ],
+        isSecret: false
       }
 
       it('Should return 400 if name is empty or null', async () => {
         const noName = Object.assign({}, leanWorkshop)
-        noName.name = null
+        noName.descriptions[0].name = null
         const response = await request.post(projectEndpoint).send(noName).expect(400)
         expect(response.body.error.details).not.toBe(null)
       })
 
-      it('Should return 400 if name is not unique', async () => {
-        const notUniqueName = Object.assign({}, leanWorkshop)
-        notUniqueName.code = 1013
-        const response = await request.post(projectEndpoint).send(notUniqueName).expect(400)
+      it('Should return 400 if code is not unique', async () => {
+        const notUniqueCode = Object.assign({}, leanWorkshop)
+        notUniqueCode.code = 1013
+        const response = await request.post(projectEndpoint).send(notUniqueCode).expect(400)
         expect(response.body.error.details).not.toBe(null)
       })
 
@@ -198,10 +225,10 @@ describe('API Projects endpoint', () => {
         expect(response.body.error.details).not.toBe(null)
       })
 
-      it('Should return 400 if code is not unique', async () => {
-        const sameCode = Object.assign({}, leanWorkshop)
-        sameCode.name = 'Some other workshop'
-        const response = await request.post(projectEndpoint).send(sameCode).expect(400)
+      it('Should return 400 if name is not unique', async () => {
+        const sameName = Object.assign({}, leanWorkshop)
+        sameName.descriptions[0].name = 'Some other workshop'
+        const response = await request.post(projectEndpoint).send(sameName).expect(400)
         expect(response.body.error.details).not.toBe(null)
       })
 

--- a/test/api/users.spec.js
+++ b/test/api/users.spec.js
@@ -141,8 +141,7 @@ describe('API Users endpoint', () => {
   describe('Deleting users', () => {
     it('should be allowed only for admins to delete users', async () => {
       await request.delete(endpoint + userId)
-        .expect('Content-Type', /json/)
-        .expect(403)
+        .expect(401)
     })
 
     it('should allow admins to delete users', async () => {

--- a/test/mockData/mockProjects.js
+++ b/test/mockData/mockProjects.js
@@ -1,20 +1,55 @@
 
 const webapp = {
   code: 1000,
-  name: 'GIS Webapp',
   startDate: new Date('2019-01-10').toISOString(),
   endDate: new Date('2019-01-31').toISOString(),
-  description: 'Creating web app with React + Leaflet'
+  descriptions: [
+    {
+      id: 1, // first item in projectDescriptions
+      description: 'Creating web app with React + Leaflet',
+      name: 'First Project',
+      language: 'en',
+      customerName: 'Best customer ever'
+    }
+  ],
+  isSecret: false,
+  projectSkills: []
 }
 
 const customerHelp = {
   code: 1001,
-  name: 'Smart solutions',
   startDate: new Date('2018-10-01').toISOString(),
   endDate: null,
-  description: 'Two consultants sold indefinitely to help customer\'s development team'
+  descriptions: [
+    {
+      id: 2, // second item in projectDescriptions
+      description: 'Two consultants sold indefinitely to help customer\'s development team',
+      name: 'Second Project',
+      language: 'en',
+      customerName: 'Best customer ever'
+    }
+  ],
+  isSecret: false,
+  projectSkills: []
 }
 
+const projectDescriptions = [
+  {
+    projectId: 1,
+    description: 'Creating web app with React + Leaflet',
+    name: 'First Project',
+    language: 'en',
+    customerName: 'Best customer ever'
+  },
+  {
+    projectId: 2,
+    description: 'Two consultants sold indefinitely to help customer\'s development team',
+    name: 'Second Project',
+    language: 'en',
+    customerName: 'Best customer ever'
+  }
+]
 module.exports = {
-  projects: [webapp, customerHelp]
+  projects: [webapp, customerHelp],
+  projectDescriptions: projectDescriptions
 }

--- a/test/mockData/mockUsers.js
+++ b/test/mockData/mockUsers.js
@@ -24,10 +24,17 @@ const basicUsersProfile = {
   email: 'basic.user@codento.com',
   phone: '0401231234',
   title: 'Consultant',
-  description: 'Just consulting about everything',
   links: [],
   photoPath: 'from/somewhere',
-  active: basicUser.active
+  active: basicUser.active,
+  cvDescriptions: [
+    {
+      id: 1, // first item in cvDescriptions
+      description: 'Just consulting about everything',
+      type: 'introduction',
+      language: 'fi'
+    }
+  ]
 }
 
 const adminUsersProfile = {
@@ -38,15 +45,36 @@ const adminUsersProfile = {
   email: 'admin.user@codento.com',
   phone: '0401231234',
   title: 'Manager',
-  description: 'Just managing about everything',
   links: [],
   photoPath: 'from/somewhere',
-  active: adminUser.active
+  active: adminUser.active,
+  cvDescriptions: [
+    {
+      id: 2, // second item in cvDescriptions
+      description: 'Just managing about everything',
+      type: 'introduction',
+      language: 'fi'
+    }
+  ]
 }
 
-const userProfiles = [basicUsersProfile, adminUsersProfile]
+const cvDescriptions = [
+  {
+    profileId: 1,
+    description: 'Just consulting about everything',
+    type: 'introduction',
+    language: 'fi'
+  },
+  {
+    profileId: 2,
+    description: 'Just managing about everything',
+    type: 'introduction',
+    language: 'fi'
+  }
+]
 
 module.exports = {
   users,
-  profiles: userProfiles
+  profiles: [basicUsersProfile, adminUsersProfile],
+  cvDescriptions: cvDescriptions
 }

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -3,10 +3,10 @@ require('babel-polyfill')
 
 const { Op } = require('sequelize')
 const { migrationsUmzug } = require('./utils')
-const { user, profile, skill, skillCategory, skillGroup, project } = require('../src/db/models/')
-const { users, profiles } = require('./mockData/mockUsers')
+const { user, profile, profileCvDescription, skill, skillCategory, skillGroup, project, projectDescription } = require('../src/db/models/')
+const { users, profiles, cvDescriptions } = require('./mockData/mockUsers')
 const { skills, skillCategories, skillGroups } = require('./mockData/mockSkills')
-const { projects } = require('./mockData/mockProjects')
+const { projects, projectDescriptions } = require('./mockData/mockProjects')
 const tearDown = require('./testTeardown')
 
 module.exports = async function () {
@@ -30,10 +30,12 @@ const insertTestData = async () => {
 const insertTestUsersWithProfiles = async () => {
   await user.bulkCreate(users)
   await profile.bulkCreate(profiles)
+  await profileCvDescription.bulkCreate(cvDescriptions)
 }
 
 const insertProjects = async () => {
   await project.bulkCreate(projects)
+  await projectDescription.bulkCreate(projectDescriptions)
 }
 
 const createSkills = async () => {


### PR DESCRIPTION
Most of the broken tests fixed.
Broken features:
* projects/<projectId>/profiles/<profileId> returns null instead of a profile object
* profiles/<profileId>/projects/<projectId> returns null instead of a project object

Broken tests (feature seems to be working):
* if cv is imported in app.js, all tests fail 
* When anything throws PermissionDenied Error (test says Error [object Object] thrown)